### PR TITLE
[shorteners] ensure shortener cleanup

### DIFF
--- a/aiourlshortener/shorteners/__init__.py
+++ b/aiourlshortener/shorteners/__init__.py
@@ -70,7 +70,12 @@ class Shortener(object):
         if not self.kwargs.get('timeout'):
             self.kwargs['timeout'] = 10
 
-        self.shorten = yield from self._class(**self.kwargs).short(url)
+        instance = self._class(**self.kwargs)
+        try:
+            self.shorten = yield from instance.short(url)
+        finally:
+            yield from instance.close()
+
         return self.shorten
 
     @coroutine
@@ -90,5 +95,10 @@ class Shortener(object):
         if not self.kwargs.get('timeout'):
             self.kwargs['timeout'] = 10
 
-        self.expanded = yield from self._class(**self.kwargs).expand(url)
+        instance = self._class(**self.kwargs)
+        try:
+            self.expanded = yield from instance.expand(url)
+        finally:
+            yield from instance.close()
+
         return self.expanded

--- a/aiourlshortener/shorteners/base.py
+++ b/aiourlshortener/shorteners/base.py
@@ -1,5 +1,3 @@
-import atexit
-
 from abc import abstractmethod
 import aiohttp
 from asyncio import coroutine
@@ -13,7 +11,6 @@ class BaseShortener(object):
     _session = None
 
     def __init__(self, **kwargs):
-        atexit.register(self.close())
         self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(use_dns_cache=True))
         self.kwargs = kwargs
 
@@ -41,6 +38,10 @@ class BaseShortener(object):
     def close(self):
         if self._session is not None:
             yield from self._session.close()
+
+    def __del__(self):
+        if self._session is not None and not self._session.closed:
+            self._session.close()
 
     @classmethod
     def __subclasshook__(cls, c):

--- a/aiourlshortener/shorteners/base.py
+++ b/aiourlshortener/shorteners/base.py
@@ -1,3 +1,5 @@
+import atexit
+
 from abc import abstractmethod
 import aiohttp
 from asyncio import coroutine
@@ -8,8 +10,10 @@ class BaseShortener(object):
     Base class for all Shorteners
     """
     api_url = None
+    _session = None
 
     def __init__(self, **kwargs):
+        atexit.register(self.close())
         self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(use_dns_cache=True))
         self.kwargs = kwargs
 
@@ -35,10 +39,8 @@ class BaseShortener(object):
 
     @coroutine
     def close(self):
-        try:
+        if self._session is not None:
             yield from self._session.close()
-        except TypeError:
-            pass
 
     @classmethod
     def __subclasshook__(cls, c):

--- a/aiourlshortener/shorteners/bitly.py
+++ b/aiourlshortener/shorteners/bitly.py
@@ -25,7 +25,6 @@ class Bitly(BaseShortener):
         params = {'access_token': self.access_token, 'longUrl': url, 'format': 'json'}
         response = yield from self._get(self._short_url, params=params)
         response = yield from response.json()
-        yield from self.close()
         if 'data' in response and isinstance(response['data'], dict) and 'url' in response['data']:
             return response['data']['url']
         raise ShorteningError('There was an error shortening this url: {}'.format(response))
@@ -35,7 +34,6 @@ class Bitly(BaseShortener):
         params = {'access_token': self.access_token, 'link': url, 'format': 'json'}
         response = yield from self._get(self._expand_url, params=params)
         response = yield from response.json()
-        yield from self.close()
         if 'data' in response and isinstance(response['data'], dict) and 'original_url' in response['data']:
             return response['data']['original_url']
         raise ExpandingError('There was an error expanding this url: {}'.format(response))

--- a/aiourlshortener/shorteners/google.py
+++ b/aiourlshortener/shorteners/google.py
@@ -26,7 +26,6 @@ class Google(BaseShortener):
         params = {'key': self.api_key}
         response = yield from self._post(self.api_url, data=json.dumps(data), params=params, headers=self._headers)
         response = yield from response.json()
-        yield from self.close()
         if 'id' in response:
             return response['id']
         raise ShorteningError('There was an error shortening this url: {}'.format(response))
@@ -36,7 +35,6 @@ class Google(BaseShortener):
         params = {'key': self.api_key, 'shortUrl': url}
         response = yield from self._get(self.api_url, params=params, headers=self._headers)
         response = yield from response.json()
-        yield from self.close()
         if 'longUrl' in response:
             return response['longUrl']
         raise ExpandingError('There was an error expanding this url: {}'.format(response))


### PR DESCRIPTION
Any `Exception` that is raised while performing an http request results in a non-closed `aiohttp.ClientSession`. The session also remains open if no HTTP request has been made.

https://github.com/blikenoother/aiourlshortener/commit/7737c138f0c8247bb8efafef35bf75248c815d1a ensures a cleanup [upon interpreter exit](https://docs.python.org/3.6/library/atexit.html#atexit.register).

There is a nice side-effect: a shortener instance can be reused for multiple request.