### PR TITLE
[setup] parse the package file instead of importing it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,21 @@
+import codecs
+import os
+import re
 from setuptools import setup, find_packages
-import aiourlshortener
 
+_PACKAGE_FILE = os.path.join(os.path.dirname(__file__),
+                             'aiourlshortener',
+                             '__init__.py')
+with codecs.open(_PACKAGE_FILE, 'r', 'utf-8') as package_reader:
+    _RAW_PACKAGE_METADATA = package_reader.read()
+
+PACKAGE_METADATA = dict(re.findall("(__[a-z]+__) = '([^']+)'",
+                                    _RAW_PACKAGE_METADATA))
 setup(
     name='aiourlshortener',
-    version=aiourlshortener.__version__,
-    license=aiourlshortener.__license__,
-    author=aiourlshortener.__author__,
+    version=PACKAGE_METADATA['__version__'],
+    license=PACKAGE_METADATA['__license__'],
+    author=PACKAGE_METADATA['__author__'],
     author_email='b.like.no.other@gmail.com',
     url='https://github.com/blikenoother/aiourlshortener',
     description='asynchronous python3 lib to short long url',


### PR DESCRIPTION
Importing the package requires our dependencies to be installed.

```bash
$ python3 -m venv /tmp/venv
$ /tmp/venv/bin/pip install .
Processing /code/aiourlshortener
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-4f7qd243-build/setup.py", line 2, in <module>
        import aiourlshortener
      File "/tmp/pip-4f7qd243-build/aiourlshortener/__init__.py", line 1, in <module>
        from .shorteners import Shortener, Shorteners
      File "/tmp/pip-4f7qd243-build/aiourlshortener/shorteners/__init__.py", line 6, in <module>
        from .base import BaseShortener
      File "/tmp/pip-4f7qd243-build/aiourlshortener/shorteners/base.py", line 2, in <module>
        import aiohttp
    ImportError: No module named 'aiohttp'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-4f7qd243-build/

```