### PR TITLE
[shorteners] reraise Exceptions of `aiohttp` as custom Exceptions

### DIFF
--- a/aiourlshortener/exceptions.py
+++ b/aiourlshortener/exceptions.py
@@ -2,6 +2,10 @@ class UnknownAioUrlShortenerError(Exception):
     pass
 
 
+class FetchError(Exception):
+    """A error occurred while fetching a remote resource"""
+
+
 class ShorteningError(Exception):
     pass
 

--- a/aiourlshortener/shorteners/bitly.py
+++ b/aiourlshortener/shorteners/bitly.py
@@ -4,8 +4,10 @@ Needs ACCESS_TOKEN
 """
 from asyncio import coroutine
 
+import aiohttp
+
 from .base import BaseShortener
-from ..exceptions import ShorteningError, ExpandingError
+from ..exceptions import ShorteningError, ExpandingError, FetchError
 
 
 class Bitly(BaseShortener):
@@ -23,19 +25,29 @@ class Bitly(BaseShortener):
     @coroutine
     def short(self, url: str) -> str:
         params = {'access_token': self.access_token, 'longUrl': url, 'format': 'json'}
-        response = yield from self._get(self._short_url, params=params)
-        response = yield from response.json()
+        try:
+            response = yield from self._get(self._short_url, params=params)
+            response = yield from response.json()
+        except (aiohttp.ClientError, FetchError) as err:
+            raise ShorteningError('There was an error shortening the url "{}": {}'.format(url, repr(err)))
+
         yield from self.close()
         if 'data' in response and isinstance(response['data'], dict) and 'url' in response['data']:
             return response['data']['url']
-        raise ShorteningError('There was an error shortening this url: {}'.format(response))
+
+        raise ShorteningError('Detected an api change for Bitly')
 
     @coroutine
     def expand(self, url: str) -> str:
         params = {'access_token': self.access_token, 'link': url, 'format': 'json'}
-        response = yield from self._get(self._expand_url, params=params)
-        response = yield from response.json()
+        try:
+            response = yield from self._get(self._expand_url, params=params)
+            response = yield from response.json()
+        except (aiohttp.ClientError, FetchError) as err:
+            raise ExpandingError('There was an error expanding the url "{}": {}'.format(url, repr(err)))
+
         yield from self.close()
         if 'data' in response and isinstance(response['data'], dict) and 'original_url' in response['data']:
             return response['data']['original_url']
-        raise ExpandingError('There was an error expanding this url: {}'.format(response))
+
+        raise ExpandingError('Detected an api change for Bitly')

--- a/aiourlshortener/shorteners/google.py
+++ b/aiourlshortener/shorteners/google.py
@@ -5,8 +5,10 @@ Needs API_KEY
 import json
 from asyncio import coroutine
 
+import aiohttp
+
 from .base import BaseShortener
-from ..exceptions import ShorteningError, ExpandingError
+from ..exceptions import ShorteningError, ExpandingError, FetchError
 
 
 class Google(BaseShortener):
@@ -24,19 +26,29 @@ class Google(BaseShortener):
     def short(self, url: str) -> str:
         data = {'longUrl': url}
         params = {'key': self.api_key}
-        response = yield from self._post(self.api_url, data=json.dumps(data), params=params, headers=self._headers)
-        response = yield from response.json()
+        try:
+            response = yield from self._post(self.api_url, data=json.dumps(data), params=params, headers=self._headers)
+            response = yield from response.json()
+        except (aiohttp.ClientError, FetchError) as err:
+            raise ShorteningError('There was an error shortening the url "{}": {}'.format(url,repr(err)))
+
         yield from self.close()
         if 'id' in response:
             return response['id']
-        raise ShorteningError('There was an error shortening this url: {}'.format(response))
+
+        raise ShorteningError('Detected an api change for Google')
 
     @coroutine
     def expand(self, url: str) -> str:
         params = {'key': self.api_key, 'shortUrl': url}
-        response = yield from self._get(self.api_url, params=params, headers=self._headers)
-        response = yield from response.json()
+        try:
+            response = yield from self._get(self.api_url, params=params, headers=self._headers)
+            response = yield from response.json()
+        except (aiohttp.ClientError, FetchError) as err:
+            raise ExpandingError('There was an error expanding the url "{}": {}'.format(url, repr(err)))
+
         yield from self.close()
         if 'longUrl' in response:
             return response['longUrl']
-        raise ExpandingError('There was an error expanding this url: {}'.format(response))
+
+        raise ExpandingError('Detected an api change for Google')


### PR DESCRIPTION
While performing a `short` or `extend` call, these `Exceptions` could be raised currently:

- `asyncio.TimeoutError` 
- any `aiohttp.ClientError`

This PR raises them as `FetchError` internally and then as `ShorteningError` or `ExtendingError` at the public api.