### PR TITLE
[shorteners] fix check for implemented `short`/`extend` methods

### DIFF
--- a/aiourlshortener/shorteners/__init__.py
+++ b/aiourlshortener/shorteners/__init__.py
@@ -15,7 +15,7 @@ for file in os.listdir(_path):
     _shorten = SourceFileLoader('aiourlshortener.shorteners.', '{}/{}'.format(_path, file)).load_module()
     for attr in dir(_shorten):
         tmp_cls = getattr(_shorten, attr)
-        if inspect.isclass(tmp_cls) and attr != 'BaseShortener' and issubclass(tmp_cls, BaseShortener):
+        if attr != 'BaseShortener' and inspect.isclass(tmp_cls) and issubclass(tmp_cls, BaseShortener) and not inspect.isabstract(tmp_cls):
             _shorten_class[attr] = tmp_cls
 
 __all__ = ['Shorteners', 'Shortener']
@@ -36,7 +36,7 @@ class Shortener(object):
         self.shorten = None
         self.expanded = None
 
-        if inspect.isclass(engine) and issubclass(engine, BaseShortener):
+        if inspect.isclass(engine) and issubclass(engine, BaseShortener) and not inspect.isabstract(engine):
             self.engine = engine.__name__
             self._class = engine
         elif engine in _shorten_class:

--- a/aiourlshortener/shorteners/base.py
+++ b/aiourlshortener/shorteners/base.py
@@ -1,9 +1,9 @@
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 import aiohttp
 from asyncio import coroutine
 
 
-class BaseShortener(object):
+class BaseShortener(ABC):
     """
     Base class for all Shorteners
     """
@@ -39,10 +39,3 @@ class BaseShortener(object):
             yield from self._session.close()
         except TypeError:
             pass
-
-    @classmethod
-    def __subclasshook__(cls, c):
-        if cls is BaseShortener:
-            if all(hasattr(c, name) for name in ('short', 'expand')):
-                return True
-        return NotImplemented


### PR DESCRIPTION
`abc.abstractmethod` requires an ABC. This PR changes the `base.BaseShortener` into an abstract base class and adds checks for engine candidates.