### PR TITLE
Refactor shortener keyword arguments

### DIFF
--- a/aiourlshortener/shorteners/__init__.py
+++ b/aiourlshortener/shorteners/__init__.py
@@ -67,9 +67,6 @@ class Shortener(object):
         url_validator(url)
         self.expanded = url
 
-        if not self.kwargs.get('timeout'):
-            self.kwargs['timeout'] = 10
-
         instance = self._class(**self.kwargs)
         try:
             self.shorten = yield from instance.short(url)
@@ -91,9 +88,6 @@ class Shortener(object):
         """
         url_validator(url)
         self.shorten = url
-
-        if not self.kwargs.get('timeout'):
-            self.kwargs['timeout'] = 10
 
         instance = self._class(**self.kwargs)
         try:

--- a/aiourlshortener/shorteners/base.py
+++ b/aiourlshortener/shorteners/base.py
@@ -16,7 +16,7 @@ class BaseShortener(ABC):
     api_url = None
     _session = None
 
-    def __init__(self, timeout=DEFAULT_TIMEOUT, **kwargs):
+    def __init__(self, timeout=DEFAULT_TIMEOUT):
         self._session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(use_dns_cache=True),
             conn_timeout=timeout,

--- a/aiourlshortener/shorteners/base.py
+++ b/aiourlshortener/shorteners/base.py
@@ -6,6 +6,9 @@ from asyncio import coroutine
 from ..exceptions import FetchError
 
 
+DEFAULT_TIMEOUT = 10
+
+
 class BaseShortener(ABC):
     """
     Base class for all Shorteners
@@ -13,9 +16,11 @@ class BaseShortener(ABC):
     api_url = None
     _session = None
 
-    def __init__(self, **kwargs):
-        self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(use_dns_cache=True))
-        self.kwargs = kwargs
+    def __init__(self, timeout=DEFAULT_TIMEOUT, **kwargs):
+        self._session = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(use_dns_cache=True),
+            conn_timeout=timeout,
+        )
 
     @coroutine
     def _get(self, url: str, params=None, headers=None):
@@ -30,9 +35,8 @@ class BaseShortener(ABC):
     @coroutine
     def _fetch(self, method: str, url: str, data=None, params=None, headers=None):
         try:
-            with aiohttp.Timeout(self.kwargs['timeout']):
-                response = yield from self._session.request(method, url, data=data, params=params, headers=headers)
-                response.raise_for_status()
+            response = yield from self._session.request(method, url, data=data, params=params, headers=headers)
+            response.raise_for_status()
         except (aiohttp.ClientError, asyncio.TimeoutError):
             raise FetchError()
         else:

--- a/aiourlshortener/shorteners/bitly.py
+++ b/aiourlshortener/shorteners/bitly.py
@@ -16,10 +16,8 @@ class Bitly(BaseShortener):
     _short_url = '{}/shorten'.format(api_url)
     _expand_url = '{}/link/info'.format(api_url)
 
-    def __init__(self, **kwargs):
-        if not kwargs.get('access_token', False):
-            raise TypeError('access_token missing from kwargs')
-        self.access_token = kwargs['access_token']
+    def __init__(self, access_token, **kwargs):
+        self.access_token = access_token
         super(Bitly, self).__init__(**kwargs)
 
     @coroutine

--- a/aiourlshortener/shorteners/google.py
+++ b/aiourlshortener/shorteners/google.py
@@ -16,10 +16,8 @@ class Google(BaseShortener):
 
     _headers = {'content-type': 'application/json'}
 
-    def __init__(self, **kwargs):
-        if not kwargs.get('api_key', False):
-            raise TypeError('api_key missing from kwargs')
-        self.api_key = kwargs['api_key']
+    def __init__(self, api_key, **kwargs):
+        self.api_key = api_key
         super(Google, self).__init__(**kwargs)
 
     @coroutine


### PR DESCRIPTION
- use the builtin mechanics to
  -  set a keyword argument default https://github.com/blikenoother/aiourlshortener/commit/d016a961d2dbe6fd052e411f6c355504f706e4c2
  - require a keyword argument https://github.com/blikenoother/aiourlshortener/commit/234a473356a952ad36cc57bd0c1c0d5e0271e9e2
- `aiohttp` can handle the connection timeout for us https://github.com/blikenoother/aiourlshortener/commit/d016a961d2dbe6fd052e411f6c355504f706e4c2

With https://github.com/blikenoother/aiourlshortener/commit/d016a961d2dbe6fd052e411f6c355504f706e4c2 we can increase or decrease the timeout [in one place](https://github.com/das7pad/aiourlshortener/blob/234a473356a952ad36cc57bd0c1c0d5e0271e9e2/aiourlshortener/shorteners/base.py#L9).